### PR TITLE
Adds migrations directory to production object in knexfile

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -54,8 +54,9 @@ module.exports = {
       max: 10
     },
     migrations: {
-      tableName: 'knex_migrations'
-    }
+      directory: './db/migrations'
+    },
+    useNullAsDefault: true
   }
 
 };


### PR DESCRIPTION
- Adds the migrations directory to the production object in knexfile.js. Was getting an error when tried to run `heroku run knex migrate:latest` that this should fix. 