### PR TITLE
Updates knexfile with database URL directly in connection key

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -26,27 +26,9 @@ module.exports = {
     useNullAsDefault: true
   },
 
-  staging: {
-    client: 'postgresql',
-    connection: {
-      database: 'my_db',
-      user:     'username',
-      password: 'password'
-    },
-    pool: {
-      min: 2,
-      max: 10
-    },
-    migrations: {
-      tableName: 'knex_migrations'
-    }
-  },
-
   production: {
     client: 'pg',
-    connection: {
-      database: 'postgres://jurubjhoqznozj:ad122d5f570d521c85fa69d69359c759edc5704f473a58807604790da0e19eff@ec2-54-225-95-183.compute-1.amazonaws.com:5432/d99g55bmomo5nj',
-    },
+    connection: 'postgres://jurubjhoqznozj:ad122d5f570d521c85fa69d69359c759edc5704f473a58807604790da0e19eff@ec2-54-225-95-183.compute-1.amazonaws.com:5432/d99g55bmomo5nj',
     pool: {
       min: 2,
       max: 10


### PR DESCRIPTION
- Updates knexfile.js from `connection: { database: <URL>` to `connection: <URL>` since the nested `database` syntax specifies a file. MySQL and SQLite need the nested `database` syntax to specify a file, Postgres does not. 
- Returns the `staging` object in knexfile.js since we are not using a staging database at this time. 