### PR TITLE
Delete favorite endpoint#9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+.env

--- a/db/migrations/20190319135122_initial.js
+++ b/db/migrations/20190319135122_initial.js
@@ -19,9 +19,9 @@ exports.up = function(knex, Promise) {
     knex.schema.createTable('playlist_favorites', function(table) {
       table.increments('id').primary();
       table.integer('favorite_id').unsigned();
-      table.foreign('favorite_id').references('favorites.id');
+      table.foreign('favorite_id').references('favorites.id').onDelete('CASCADE');
       table.integer('playlist_id').unsigned();
-      table.foreign('playlist_id').references('playlists.id');
+      table.foreign('playlist_id').references('playlists.id').onDelete('CASCADE');
 
       table.timestamps(true, true);
     })

--- a/db/migrations/20190319135122_initial.js
+++ b/db/migrations/20190319135122_initial.js
@@ -19,10 +19,9 @@ exports.up = function(knex, Promise) {
     knex.schema.createTable('playlist_favorites', function(table) {
       table.increments('id').primary();
       table.integer('favorite_id').unsigned();
-      table.foreign('favorite_id').references('favorites.id').onDelete('CASCADE');
+      table.foreign('favorite_id').references('id').on('favorites').onDelete('CASCADE');
       table.integer('playlist_id').unsigned();
-      table.foreign('playlist_id').references('playlists.id').onDelete('CASCADE');
-
+      table.foreign('playlist_id').references('id').on('playlists').onDelete('CASCADE');
       table.timestamps(true, true);
     })
   ])

--- a/index.js
+++ b/index.js
@@ -70,6 +70,23 @@ app.get('/api/v1/favorites/:id', (request, response) => {
     });
 })
 
+app.delete('/api/v1/favorites/:id', (request, response) => {
+  database('favorites').where('id', request.params.id).select()
+    .then(favorite => {
+      if(favorite.length) {
+        database('favorites')
+        .where({ id: request.params.id })
+        .del()
+        response.status(200).json('favorite')
+      } else {
+        response.status(404).json({ error: `Could not find Favorite with ID: ${request.params.id}.` });
+      }
+    })
+    .catch(error => {
+      response.status(500).json({ error })
+    });
+})
+
 app.listen(app.get('port'), () => {
   console.log(`${app.locals.title} is running on ${app.get('port')}.`);
 })

--- a/index.js
+++ b/index.js
@@ -94,7 +94,9 @@ app.put('/api/v1/favorites/:id', (request, response) => {
 
 app.delete('/api/v1/favorites/:id', (request, response) => {
   database('favorites').where('id', request.params.id).del()
-    .then( () => response.status(204).json() )
+    .then(() => {
+      response.status(204).json()
+    })
     .catch(error => {
       response.status(404).json({ error: `Could not find Favorite with ID: ${request.params.id}.` })
     });

--- a/index.js
+++ b/index.js
@@ -71,19 +71,10 @@ app.get('/api/v1/favorites/:id', (request, response) => {
 })
 
 app.delete('/api/v1/favorites/:id', (request, response) => {
-  database('favorites').where('id', request.params.id).select()
-    .then(favorite => {
-      if(favorite.length) {
-        database('favorites')
-        .where('id', request.params.id)
-        .del()
-        .then(response => {response.resolve})
-      } else {
-        response.status(404).json({ error: `Could not find Favorite with ID: ${request.params.id}.` });
-      }
-    })
+  database('favorites').where('id', request.params.id).del()
+    .then( () => response.status(204).json() )
     .catch(error => {
-      response.status(500).json({ error })
+      response.status(404).json({ error: `Could not find Favorite with ID: ${request.params.id}.` })
     });
 })
 

--- a/index.js
+++ b/index.js
@@ -75,9 +75,9 @@ app.delete('/api/v1/favorites/:id', (request, response) => {
     .then(favorite => {
       if(favorite.length) {
         database('favorites')
-        .where({ id: request.params.id })
+        .where('id', request.params.id)
         .del()
-        response.status(200).json('favorite')
+        .then(response => {response.resolve})
       } else {
         response.status(404).json({ error: `Could not find Favorite with ID: ${request.params.id}.` });
       }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "Play Back End",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --exit",
-    "start": "node index.js"
+    "test": "NODE_ENV=test mocha --exit",
+    "start": "NODE_ENV=development node index.js",
+    "debug": "NODE_ENV=test mocha --exit --timeout 20000"
   },
   "repository": {
     "type": "git",

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -185,25 +185,15 @@ describe('API Routes', () => {
     });
   });
 
-  describe('DELETE /api/v1/favorites/:id', () => {
-    it('should delete a specified favorite from the database', done => {
-      chai.request(server)
-      .get('/api/v1/favorites/1')
-      .end((error, response) => {
-        chai.request(server)
-        .delete('/favorites/' + response.body[0].id)
-        .end((error, response) => {
-          response.should.have.status(200);
-          response.should.be.json;
-          response.body.should.be.a('object');
-          response.body.should.have.property('REMOVED');
-          response.body.REMOVED.should.be.a('object');
-          response.body.REMOVED.should.have.property('name');
-          response.body.REMOVED.should.have.property('_id');
-          response.body.REMOVED.name.should.equal('song_1');
-          done();
-        })
-      })
-    })
-  })
+  // describe('DELETE /api/v1/favorites/:id', () => {
+  //   it('should delete a specified favorite from the database', done => {
+  //       chai.request(server)
+  //       .del('/api/v1/favorites/1')
+  //       .end((error, response) => {
+  //         // eval(pry.it)
+  //         response.should.have.status(204);
+  //         done();
+  //       })
+  //     })
+  //   })
 });

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -3,7 +3,7 @@ const should = chai.should();
 const chaiHttp = require('chai-http');
 const pry = require('pryjs')
 
-const environment = process.env.NODE_ENV || 'test';
+const environment = 'test';
 const server = require('../index.js').app;
 const config = require('../knexfile.js')[environment];
 const database = require('knex')(config);
@@ -22,7 +22,7 @@ describe('API Routes', () => {
         throw error;
       });
   });
-  
+
   beforeEach(done => {
     database.raw("TRUNCATE playlist_favorites restart identity;")
       .then(() => database.raw("TRUNCATE playlists restart identity CASCADE;"))
@@ -36,7 +36,7 @@ describe('API Routes', () => {
             throw error;
     });
   });
-  
+
   describe('GET /api/v1/favorites', () => {
     it('should return all of the favorites', done => {
       chai.request(server)
@@ -54,7 +54,7 @@ describe('API Routes', () => {
         });
     });
   });
-  
+
   describe('POST /api/v1/favorites', () => {
     it('should add a new favorite', done => {
       chai.request(server)
@@ -80,14 +80,14 @@ describe('API Routes', () => {
             done();
           })
     });
-    
+
     it('should not create a new favorite with missing data', done => {
       chai.request(server)
         .post('/api/v1/favorites')
           .send({
             "favorites": {
               "name": "Missing stuff"
-            } 
+            }
           })
           .end((error, response) => {
             response.should.have.status(400);
@@ -97,7 +97,7 @@ describe('API Routes', () => {
             done();
           });
     });
-    
+
     it('should not create a new favorite with a rating over 100', done => {
       chai.request(server)
         .post('/api/v1/favorites')
@@ -118,7 +118,7 @@ describe('API Routes', () => {
             done();
           });
     });
-    
+
     it('should not create a new favorite with a rating under 0', done => {
       chai.request(server)
         .post('/api/v1/favorites')
@@ -139,7 +139,7 @@ describe('API Routes', () => {
             done();
           });
     });
-    
+
     it('should not create a new favorite with a rating that is not a number', done => {
       chai.request(server)
       .post('/api/v1/favorites')
@@ -161,7 +161,7 @@ describe('API Routes', () => {
         });
     });
   });
-  
+
   describe('GET /api/v1/favorites/:id', () => {
     it('should get the specified favorite information', done => {
       chai.request(server)
@@ -174,7 +174,7 @@ describe('API Routes', () => {
           done();
         });
     });
-    
+
     it('should return an error if the specified ID does not exist', done => {
       chai.request(server)
         .get('/api/v1/favorites/400')
@@ -184,4 +184,26 @@ describe('API Routes', () => {
         });
     });
   });
+
+  describe('DELETE /api/v1/favorites/:id', () => {
+    it('should delete a specified favorite from the database', done => {
+      chai.request(server)
+      .get('/api/v1/favorites/1')
+      .end((error, response) => {
+        chai.request(server)
+        .delete('/favorites/' + response.body[0].id)
+        .end((error, response) => {
+          response.should.have.status(200);
+          response.should.be.json;
+          response.body.should.be.a('object');
+          response.body.should.have.property('REMOVED');
+          response.body.REMOVED.should.be.a('object');
+          response.body.REMOVED.should.have.property('name');
+          response.body.REMOVED.should.have.property('_id');
+          response.body.REMOVED.name.should.equal('song_1');
+          done();
+        })
+      })
+    })
+  })
 });

--- a/test/routes.spec.js
+++ b/test/routes.spec.js
@@ -186,17 +186,16 @@ describe('API Routes', () => {
   });
 
 
-  // describe('DELETE /api/v1/favorites/:id', () => {
-  //   it('should delete a specified favorite from the database', done => {
-  //       chai.request(server)
-  //       .del('/api/v1/favorites/1')
-  //       .end((error, response) => {
-  //         // eval(pry.it)
-  //         response.should.have.status(204);
-  //         done();
-  //       })
-  //     })
-  //   })
+  describe('DELETE /api/v1/favorites/:id', () => {
+    it('should delete a specified favorite from the database', done => {
+        chai.request(server)
+        .del('/api/v1/favorites/1')
+        .end((error, response) => {
+          response.should.have.status(204);
+          done();
+        })
+      })
+    })
 
   
   describe('PUT /api/v1/favorites/:id', () => {


### PR DESCRIPTION
#### Pivotal URL or Waffle Card number: #9 
closes #9 
#### What does this PR do?
Adds endpoint to the API for favorites. It allows a user to delete a favorite.
#### Where should the reviewer start?
The delete method is contained at the bottom of the other endpoints under index.js.
#### Note: Need to remember to run ALL FOUR of the following commands, and will also need to rollback and migrate production once deployed:
- `knex migrate:rollback`
- `knex migrate:latest` 
- `knex migrate:rollback --env test`
- `knex migrate:latest --env test` 